### PR TITLE
Remove ellipsis and add description to blog cards

### DIFF
--- a/src/pages/blog.jsx
+++ b/src/pages/blog.jsx
@@ -31,11 +31,11 @@ const BlogHome = ({ data }) => {
           ]}
           gap={6}
         >
-          {data.allMdx.nodes.map(({ excerpt, frontmatter, id }) => (
+          {data.allMdx.nodes.map(({ frontmatter, id }) => (
             <Card
               key={id}
-              heading={frontmatter.title.slice(0, 60) + `...`}
-              body={excerpt}
+              heading={frontmatter.title}
+              body={frontmatter.description}
               link={`/blog/${frontmatter.slug}/`}
               label={`Read the blog: ${frontmatter.title}.`}
             >
@@ -84,9 +84,9 @@ export const query = graphql`
     allMdx(sort: { fields: [frontmatter___date], order: DESC }) {
       nodes {
         id
-        excerpt(pruneLength: 80)
         frontmatter {
           title
+          description
           date(formatString: "Do MMM")
           slug
           authors {


### PR DESCRIPTION
Some styling tweaks to the main `Blog` page 👩‍🎨 

- Removed ellipsis from the title preview. Right now, the `...` are being added to every post because most are short enough to fit the indicated slice. In theory, titles should always be short enough to fit and I'd rather be more mindful of that and keep this page clean than add `...`
- Changed out `excerpt` in favor of our `description` data. Cleaner and gives a more accurate preview than the first 80 characters.