### PR TITLE
[MEM-165] Rename Meeshkan to Mem on homepage

### DIFF
--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -122,9 +122,9 @@ const IndexPage = () => (
         gap={6}
       >
         <Card
-          heading="Meeshkan"
-          link="https://github.com/meeshkan/meeshkan"
-          label="Learn more about Meeshkan"
+          heading="Mem"
+          link="https://github.com/meeshkan/mem"
+          label="Learn more about Mem"
           body="Building OpenAPI specifications from HTTP recordings and a place to
             store the HTTP traffic logs."
         >


### PR DESCRIPTION
Blocked by https://github.com/meeshkan/meeshkan/pull/186

As decided in the new product discussions, we will be renaming this product to `Mem` in favor of our new product having the `Meeshkan` name.

This PR covers the homepage. 