### PR TITLE
[MEM-412] Fix canonical urls

### DIFF
--- a/src/components/templates/blogPost.tsx
+++ b/src/components/templates/blogPost.tsx
@@ -26,7 +26,6 @@ type BlogPostProps = {
 const BlogPost = ({ data, pageContext }: BlogPostProps) => {
   const { frontmatter, body } = data.mdx
   const { previous, next } = pageContext
-  console.log(frontmatter.slug)
   return (
     <Layout>
       <MDXProvider components={mdxComponents}>


### PR DESCRIPTION
### Two issues fixed with this PR:
* We were using relative URLs to populate the `href` when it should've been absolute - for example, `/blog/extensions-in-ts/` has been changed to `https://meeshkan.com/blog/extensions-in-ts/`.
* When another URL was entered as the `canonicalURL` in frontmatter, it was being rendered in the `href` as `/blog/{canonicalURL}`. Now it'll be `{canonicalURL}`.

Only made changes to `src/components/templates/blogPost.tsx` but I checked the other website pages and it's working properly for those as well. 