### PR TITLE
Docs: Temporarily remove search bar

### DIFF
--- a/src/components/docsComponents/docsNavigation.tsx
+++ b/src/components/docsComponents/docsNavigation.tsx
@@ -47,8 +47,8 @@ const DocsNavigation = () => {
           </Code>
         </Link>
       </Link>
-      {/* Search bar */}
-      <Stack isInline display={["none", "none", "block"]}>
+      {/* Search bar - temporarily removed until functionality is fixed */}
+      {/* <Stack isInline display={["none", "none", "block"]}>
         <InputGroup size="sm" minW={200}>
           <InputLeftElement
             children={<Icon name="search" color="gray.300" />}
@@ -59,7 +59,7 @@ const DocsNavigation = () => {
             className="algolia-search-bar"
           />
         </InputGroup>
-      </Stack>
+      </Stack> */}
       {/* Mobile Nav | Button & Menu Drawer */}
       <Box display={["block", "block", "none"]}>
         <IconButton


### PR DESCRIPTION
### What's in this PR
* Commented out the Search bar and associated stack
* Added an inline comment saying this is temporary 

### Why?
While we're fixing the functionality of the docs search bar, I'd suggest temporarily removing it. Mostly so that it doesn't distract users, but also because it's not a great look to have something broken prominently featured in our main nav.

The fix is in progress with [MEM-747](https://linear.app/meeshkan/issue/MEM-747/broken-search-in-the-documentation).