### PR TITLE
[MEM-701] Add Resources section to footer

### DIFF
--- a/src/components/organisms/footer.tsx
+++ b/src/components/organisms/footer.tsx
@@ -16,10 +16,18 @@ export function Footer() {
     <Box as="footer" bg="gray.50" p={6}>
       <Box maxW="1000px" mx="auto">
         <Flex wrap="wrap" justify="center">
-          <Stack my={4} w={["100%", "50%"]}>
+          <Stack my={4} w={["100%", "33%"]}>
             <Heading as="h4" color="gray.900" fontSize="xl" fontWeight={900}>
               Company
             </Heading>
+            <Link
+              // @ts-ignore
+              as={GatsbyLink}
+              to="/about/"
+              aria-label="About the Meeshkan team"
+            >
+              About us
+            </Link>
             <Link
               // @ts-ignore
               as={GatsbyLink}
@@ -39,30 +47,50 @@ export function Footer() {
             <Link
               // @ts-ignore
               as={GatsbyLink}
-              to="/about/"
-              aria-label="About the Meeshkan team"
-            >
-              About us
-            </Link>
-            <Link
-              // @ts-ignore
-              as={GatsbyLink}
               to="/terms-and-conditions/"
               aria-label="Terms and conditions of the Meeshkan product"
               title="terms and conditions"
             >
               T&amp;C
             </Link>
+          </Stack>
+          <Stack my={4} w={["100%", "33%"]}>
+            <Heading as="h4" color="gray.900" fontSize="xl" fontWeight={900}>
+              Resources
+            </Heading>
             <Link
               // @ts-ignore
               as={GatsbyLink}
               to="/docs/"
               aria-label="Meeshkan's documentation"
             >
-              Docs
+              Documentation
+            </Link>
+            <Link
+              // @ts-ignore
+              as={GatsbyLink}
+              to="/docs/faq/"
+              aria-label="Frequently asked questions about Meeshkan"
+            >
+              FAQ
+            </Link>
+            <Link
+              // @ts-ignore
+              as={GatsbyLink}
+              to="/blog/"
+              aria-label="Meeshkan's blog"
+            >
+              Blog
+            </Link>
+            <Link
+              isExternal
+              href="https://gitter.im/Meeshkan/community"
+              aria-label="Go to Meeshkan's Gitter community"
+            >
+              Community
             </Link>
           </Stack>
-          <Stack my={4} w={["100%", "50%"]}>
+          <Stack my={4} w={["100%", "33%"]}>
             <Heading as="h4" color="gray.900" fontSize="xl" fontWeight={900}>
               Related links
             </Heading>


### PR DESCRIPTION
## Description
- Added a section of links called `Resources` to the footer
- Links to `Documentation`, `FAQ`, `Blog` and `Community` (Gitter)
- Also very slightly reordered the `Company` section

<img width="1129" alt="Screen Shot 2020-06-09 at 11 34 26 PM" src="https://user-images.githubusercontent.com/26869552/84203744-48c12080-aaaa-11ea-87be-2faa827100d6.png">
