### PR TITLE
Change color of blockquote element on blog

### DIFF
--- a/src/components/molecules/mdxComponents.tsx
+++ b/src/components/molecules/mdxComponents.tsx
@@ -104,8 +104,10 @@ const components = {
       my={6}
       rounded="sm"
       variant="left-accent"
-      color="gray.600"
-      fontWeight="600"
+      backgroundColor="blue.50"
+      color="blue.500"
+      fontWeight="500"
+      fontStyle="italic"
       status="info"
       css={{ "> *:first-of-type": { marginTop: 0 } }}
       {...props}


### PR DESCRIPTION
Whenever I share our blog posts, someone always points out how our blockquote elements look like an error. This week I also shared our blog in a dev blogging group and received the feedback that if our CTAs are red, we shouldn't have anything else on the page be the same color.

All of this made sense to me, so this PR opts to change the blockquote from the red `error` status to the blue `info` status. Semantically it makes more sense, plus it was IMO the best color choice for it out of the Chakra options 🤷 

Open to any changes though! 

Here's what it looks like now for the two most common use cases...

At the top of a post:
<img width="1105" alt="Screen Shot 2020-07-24 at 4 53 18 PM" src="https://user-images.githubusercontent.com/26869552/88404465-371fa800-cdce-11ea-8302-15abecd7f193.png">

After a code block:
<img width="1077" alt="Screen Shot 2020-07-24 at 4 52 19 PM" src="https://user-images.githubusercontent.com/26869552/88404382-1c4d3380-cdce-11ea-9b18-19929895da97.png">
