### PR TITLE
Fix link pointing to incorrect endpoint

### DIFF
--- a/src/pages/pricing.tsx
+++ b/src/pages/pricing.tsx
@@ -128,6 +128,7 @@ const PricingPage = () => {
           <ChakraLink
             // @ts-ignore
             as={Link}
+            to="/contact"
             color="blue.500"
           >
             {" "}


### PR DESCRIPTION
- "Let us know" in `/pricing` was pointing to `/` instead of `/contact`.