### PR TITLE
Add link to docker resources

### DIFF
--- a/src/pages/docs/how-meeshkan-works.mdx
+++ b/src/pages/docs/how-meeshkan-works.mdx
@@ -9,7 +9,6 @@ Testing is the core of what Meeshkan does and it's important that we're transpar
 - [Running the tests](#running-the-tests)
 - [Testing frequency](#testing-frequency)
 - [Reporting bugs and issues](#reporting-bugs-and-issues)
-- [Project configuration](#project-configuration)
 - [Suggested fixes](#suggested-fixes)
 
 ## Running the tests
@@ -34,32 +33,6 @@ We're currently experimenting with the most effective way to report bugs. By def
 ![Branch checks on GitHub](https://media.graphcms.com/LN6VPBZQGWwERj6RjeZw)
 
 Other options we're exploring include email digests, Slack notifications, and filing an issue on the registered repository.
-
-## Project configuration
-
-Each project has configuration settings that will allow Meeshkan tests to run automatically. If you'd like tests to run on every commit, please enter your build settings!
-
-![Configuration UI](https://media.graphcms.com/FdmqxNNqT5iWaT31FXEA)
-
-You can find your project's configuration at `https://app.meeshkan.com/{yourTeam}/{yourProject}/configuration`.
-
-### Build settings
-
-Please add credentials for your local server, and not your live endpoints. Testing against production credentials can cause permanent data damage.
-- **Root directory**: The path to your app in your repository. For instance, if your app lives in the home directory, then you would use `./` as your root directory. 
-- **Build command**: The command(s) your app framework provides for compiling your code. `npm install && npm start` is an example build command for a repository that uses NPM and provides a "start" script.
-- **OpenAPI location**: The path or endpoint to your repository's *OpenAPI specification* (such as `http://localhost:8000/api/openapi`).
-- **GraphQL endpoint**: The path or endpoint to your repository's *GraphQL schema* (such as `http://localhost:8000/api/graphql`).
-
-#### Docker
-
-In several cases, you might want to 'dockerize' your project and provide your `docker-compose up` command (or equivalent) as the Meeshkan *build command*. Here is a list of a few resources that may be useful in the 'dockerization' process:
-- [Docker's *Get Started* Guide](https://docs.docker.com/get-started/)
-- [Node.js's *Dockerizing a Node.js web app* Guide](https://nodejs.org/en/docs/guides/nodejs-docker-webapp/)
-
-### Slack integration
-
-Our slack app allows you to recieve notifications in the channel of your choosing. Currently notifications are global for any bugs found. In the future we will expose granular controls to allow you to only recieve notifications for high priority bugs.
 
 ## Suggested fixes
 

--- a/src/pages/docs/index.mdx
+++ b/src/pages/docs/index.mdx
@@ -12,6 +12,7 @@ If you have any questions, you can always [contact us for support](/contact/).
 - [What does Meeshkan do?](#what-does-meeshkan-do)
 - [Creating your Meeshkan account](#creating-your-meeshkan-account)
 - [Authorizing Meeshkan on GitHub](#authorizing-meeshkan-on-github)
+- [Configuring your projects](#configuring-your-projects)
 - [How Meeshkan reports bugs](#how-meeshkan-reports-bugs)
 - [Revoking access](#revoking-access)
 - [Deleting your account](#deleting-your-account)
@@ -55,9 +56,33 @@ Here's what that'll look like if you substitute `Unmock` for your organization n
 
 After this, you'll land on the webapp homepage <span role="img" aria-label="party popper">🎉</span>
 
-Finally, you can follow the [project configuration guide](/docs/how-meeshkan-works/#project-configuration) to get Meeshkan up and running in a matter of seconds.
-
 For more detailed information about the permissions we require, please read our [Required permissions](/docs/required-permissions/) page.
+
+## Configuring your projects
+
+Each project has configuration settings that will allow Meeshkan tests to run automatically. If you'd like tests to run on every commit, please enter your build settings!
+
+![Configuration UI](https://media.graphcms.com/FdmqxNNqT5iWaT31FXEA)
+
+You can find your project's configuration at `https://app.meeshkan.com/{yourTeam}/{yourProject}/configuration`.
+
+### Build settings
+
+Please add credentials for your local server, and not your live endpoints. Testing against production credentials can cause permanent data damage.
+- **Root directory**: The path to your app in your repository. For instance, if your app lives in the home directory, then you would use `./` as your root directory. 
+- **Build command**: The command(s) your app framework provides for compiling your code. `npm install && npm start` is an example build command for a repository that uses NPM and provides a "start" script.
+- **OpenAPI location**: The path or endpoint to your repository's *OpenAPI specification* (such as `http://localhost:8000/api/openapi`).
+- **GraphQL endpoint**: The path or endpoint to your repository's *GraphQL schema* (such as `http://localhost:8000/api/graphql`).
+
+#### Docker
+
+In several cases, you might want to 'dockerize' your project and provide your `docker-compose up` command (or equivalent) as the Meeshkan *build command*. Here is a list of a few resources that may be useful in the 'dockerization' process:
+- [Docker's *Get Started* Guide](https://docs.docker.com/get-started/)
+- [Node.js's *Dockerizing a Node.js web app* Guide](https://nodejs.org/en/docs/guides/nodejs-docker-webapp/)
+
+### Slack integration
+
+Our slack app allows you to recieve notifications in the channel of your choosing. Currently notifications are global for any bugs found. In the future we will expose granular controls to allow you to only recieve notifications for high priority bugs.
 
 ## How Meeshkan reports bugs
 


### PR DESCRIPTION
- Link to resources that could help in the 'dockerization' process
- Move "project configuration" guide to the "getting started" section instead of the "how meeshkan works" section.